### PR TITLE
fix: Ensure attribute is cast to string before JSON decoding to prevent errors

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -251,7 +251,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
             if (!is_array($attribute)) {
                 if (!is_object($attribute)) {
                     if (!empty($attribute)) {
-                        $json_attribute = json_decode($attribute, true);
+                        $json_attribute = json_decode((string)$attribute, true);
                         if (json_last_error() == JSON_ERROR_NONE)
                             return $json_attribute;
                     }


### PR DESCRIPTION
[…nt errors](fix: Ensure attribute is cast to string before JSON decoding to prevent errors)